### PR TITLE
Outpustreamfactory

### DIFF
--- a/pom-package.xml
+++ b/pom-package.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.nanosai</groupId>
     <artifactId>stream-ops</artifactId>
-    <version>0.6.1</version>
+    <version>0.6.2</version>
     <packaging>jar</packaging>
 
     <name>Stream Ops for Java - Fat JAR Packaging</name>

--- a/src/main/java/com/nanosai/streamops/storage/file/IOutputStreamFactory.java
+++ b/src/main/java/com/nanosai/streamops/storage/file/IOutputStreamFactory.java
@@ -1,0 +1,11 @@
+package com.nanosai.streamops.storage.file;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public interface IOutputStreamFactory {
+
+
+    public OutputStream createOutputStream(String filePath) throws IOException;
+
+}

--- a/src/test/java/com/nanosai/streamops/examples/ecommerce/StreamWriteExample.java
+++ b/src/test/java/com/nanosai/streamops/examples/ecommerce/StreamWriteExample.java
@@ -4,7 +4,9 @@ import com.nanosai.rionops.rion.write.RionWriter;
 import com.nanosai.streamops.storage.file.StreamStorageFS;
 import com.nanosai.streamops.util.FileUtil;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +30,10 @@ public class StreamWriteExample {
         FileUtil.resetDir(new File(streamDir));
 
         StreamStorageFS streamStorage = new StreamStorageFS(streamId, streamDir, 8 * 1024 * 1024);
+        streamStorage.setOutputStreamFactory((String filePath) -> {
+           return new BufferedOutputStream(new FileOutputStream(filePath), 8 * 1024);
+        });
+
         streamStorage.openForAppend();
 
         long noOfOrders = 10;
@@ -69,7 +75,7 @@ public class StreamWriteExample {
         System.out.println("Time   : " + fullTime);
         System.out.println("Records: " + noOfOrderItems);
 
-        System.out.println("Speed  :" + noOfOrderItems * 1000 / fullTime);
+        System.out.println("Speed  :" + noOfOrderItems * 1000L / fullTime);
 
 
     }

--- a/src/test/java/com/nanosai/streamops/storage/file/StreamStorageFSTest.java
+++ b/src/test/java/com/nanosai/streamops/storage/file/StreamStorageFSTest.java
@@ -36,13 +36,13 @@ public class StreamStorageFSTest {
         streamStorageFS.appendRecord(rionBytesRecord, 0, rionBytesRecord.length);
         streamStorageFS.closeForAppend();
 
-        assertEquals(13, streamStorageFS.getLatestBlock().fileLength);
+        assertEquals(14, streamStorageFS.getLatestBlock().fileLength);
 
         streamStorageFS.openForAppend();
         streamStorageFS.appendRecord(rionBytesRecord, 0, rionBytesRecord.length);
         streamStorageFS.closeForAppend();
 
-        assertEquals(23, streamStorageFS.getLatestBlock().fileLength);
+        assertEquals(24, streamStorageFS.getLatestBlock().fileLength);
 
     }
 
@@ -73,9 +73,9 @@ public class StreamStorageFSTest {
         streamStorageFS.closeForAppend();
 
         assertEquals(3, streamStorageFS.getStorageBlocks().size());
-        assertEquals(13, streamStorageFS.getStorageBlocks().get(0).fileLength);
-        assertEquals(19, streamStorageFS.getStorageBlocks().get(1).fileLength);
-        assertEquals( 9, streamStorageFS.getStorageBlocks().get(2).fileLength);
+        assertEquals(14, streamStorageFS.getStorageBlocks().get(0).fileLength);
+        assertEquals(20, streamStorageFS.getStorageBlocks().get(1).fileLength);
+        assertEquals(10, streamStorageFS.getStorageBlocks().get(2).fileLength);
 
         byte[] dest1 = new byte[14];
 


### PR DESCRIPTION
Adds an IOutputStreamFactory interface to stream storage, so the StreamStorageFS class can now take an IOutputStreamFactory instance. Thus, you can use BufferedOutputStream or a custom OutputStream subclass if you desire. StreamStorageFS also has a new method named <code>flush()</code> which will flush data to disk (call flush() on the OutputStream for the current stream file block).