### PR TITLE
partial iteration feature added

### DIFF
--- a/pom-package.xml
+++ b/pom-package.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.nanosai</groupId>
     <artifactId>stream-ops</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <packaging>jar</packaging>
 
     <name>Stream Ops for Java - Fat JAR Packaging</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.nanosai</groupId>
     <artifactId>stream-ops</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <packaging>jar</packaging>
 
     <name>Stream Ops for Java</name>


### PR DESCRIPTION
Makes it possible to iterate a stream from a specific offset and forward, rather than starting from the first offset in the stream every single time.